### PR TITLE
#SBCOSS-620 feat: Add content metadata event generation

### DIFF
--- a/publish-pipeline/content-publish/src/main/resources/content-publish.conf
+++ b/publish-pipeline/content-publish/src/main/resources/content-publish.conf
@@ -8,6 +8,7 @@ kafka {
   input.topic = "sunbirddev.publish.job.request"
   post_publish.topic = "sunbirddev.content.postpublish.request"
   mvc.topic = "sunbirddev.mvc.processor.job.request"
+  content_metadata.topic = "sunbirddev.telemetry.coss"
   error.topic = "sunbirddev.learning.events.failed"
   groupId = "local-content-publish-group"
 }

--- a/publish-pipeline/content-publish/src/main/resources/content-publish.conf
+++ b/publish-pipeline/content-publish/src/main/resources/content-publish.conf
@@ -25,6 +25,10 @@ redis {
   }
 }
 
+# AI Search enabled config
+# Even if this config is not present, it will be set to false by default
+ai_search_enabled = false
+
 content {
   bundleLocation = "/tmp/contentBundle"
   isECARExtractionEnabled = true

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/CollectionPublishFunction.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/CollectionPublishFunction.scala
@@ -135,7 +135,9 @@ class CollectionPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil
 
           if (!isCollectionShallowCopy) syncNodes(successObj, updatedChildren, unitNodes)(esUtil, neo4JUtil, cassandraUtil, readerConfig, definition, config)
           pushPostProcessEvent(successObj, dialContextMap, context)(metrics)
-          pushContentMetadataEvent(successObj, context)(metrics)
+          if(config.isAISearchEnabled) {
+            pushContentMetadataEvent(successObj, context)(metrics)
+          }
           logger.info(s"KN-856: Step:9 - After pushPostProcessEvent Collection:  ${successObj.identifier} | Hierarchy: ${successObj.hierarchy}");
           metrics.incCounter(config.collectionPublishSuccessEventCount)
           logger.info("CollectionPublishFunction:: Collection publishing completed successfully for : " + data.identifier)

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/CollectionPublishFunction.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/CollectionPublishFunction.scala
@@ -280,7 +280,7 @@ class CollectionPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil
       "createdFor", "size", "compatibilityLevel", "os", "lockKey", "code",
       "showNotification", "version", "language", "dialcodeRequired", "lastSubmittedOn",
       "interceptionPoints", "idealScreenSize", "contentEncoding", "consumerId",
-      "osId", "contentDisposition", "previewUrl", "credentials", "pkgVersion",
+      "osId", "contentDisposition", "previewUrl", "credentials",
       "idealScreenDensity", "lastUpdatedOn", "createdOn", "lastPublishedOn",
       "lastPublishedBy", "createdBy", "lastUpdatedBy", "objectType", "visibility",
       "ownershipType", "nodeType", "status", "versionKey"

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/CollectionPublishFunction.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/CollectionPublishFunction.scala
@@ -135,6 +135,7 @@ class CollectionPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil
 
           if (!isCollectionShallowCopy) syncNodes(successObj, updatedChildren, unitNodes)(esUtil, neo4JUtil, cassandraUtil, readerConfig, definition, config)
           pushPostProcessEvent(successObj, dialContextMap, context)(metrics)
+          pushContentMetadataEvent(successObj, context)(metrics)
           logger.info(s"KN-856: Step:9 - After pushPostProcessEvent Collection:  ${successObj.identifier} | Hierarchy: ${successObj.hierarchy}");
           metrics.incCounter(config.collectionPublishSuccessEventCount)
           logger.info("CollectionPublishFunction:: Collection publishing completed successfully for : " + data.identifier)
@@ -191,6 +192,114 @@ class CollectionPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil
     val failedEvent = if (error == null) getFailedEvent(event.jobName, event.getMap(), errorMessage) else getFailedEvent(event.jobName, event.getMap(), error)
     context.output(config.failedEventOutTag, failedEvent)
     metrics.incCounter(config.collectionPublishFailedEventCount)
+  }
+
+  private def pushContentMetadataEvent(obj: ObjectData, context: ProcessFunction[Event, String]#Context)(implicit metrics: Metrics): Unit = {
+    val event = getContentMetadataEvent(obj)
+    context.output(config.contentMetadataEventOutTag, event)
+    try {
+      if (metrics != null) {
+        metrics.incCounter(config.collectionPublishSuccessEventCount)
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error incrementing metrics for ${obj.identifier}: ${e.getMessage}")
+    }
+  }
+
+  def getContentMetadataEvent(obj: ObjectData): String = {
+    // Standard fields
+    val standardFields = Map(
+      "name" -> obj.getString("name", ""),
+      "description" -> obj.getString("description", ""),
+      "keywords" -> obj.metadata.getOrElse("keywords", List.empty),
+      "appIcon" -> obj.getString("appIcon", ""),
+      "mimeType" -> obj.getString("mimeType", ""),
+      "gradeLevel" -> obj.metadata.getOrElse("gradeLevel", List.empty),
+      "identifier" -> obj.getString("identifier", ""),
+      "medium" -> obj.metadata.getOrElse("medium", List.empty),
+      "pkgVersion" -> obj.metadata.getOrElse("pkgVersion", 0),
+      "board" -> obj.getString("board", ""),
+      "subject" -> obj.metadata.getOrElse("subject", List.empty),
+      "resourceType" -> obj.getString("resourceType", ""),
+      "primaryCategory" -> obj.getString("primaryCategory", ""),
+      "contentType" -> obj.getString("contentType", ""),
+      "channel" -> obj.getString("channel", ""),
+      "organisation" -> obj.metadata.getOrElse("organisation", List.empty),
+      "trackable" -> obj.metadata.getOrElse("trackable", Map.empty),
+      "artifactUrl" -> obj.getString("artifactUrl", ""),
+      "license" -> obj.getString("license", ""),
+      "author" -> obj.getString("author", ""),
+      "creator" -> obj.getString("creator", ""),
+      "audience" -> obj.metadata.getOrElse("audience", List.empty)
+    )
+    
+    // Get framework-specific fields
+    val frameworkFields = getFrameworkFields(obj)
+    
+    // Combine standard and framework fields
+    val allFields = standardFields ++ frameworkFields
+    
+    val eventDataJson = ScalaJsonUtil.serialize(allFields)
+    logger.info(s"Content Metadata Event for collection ${obj.identifier} is: $eventDataJson")
+    eventDataJson
+  }
+  
+  private def getFrameworkFields(obj: ObjectData): Map[String, AnyRef] = {
+    val frameworkId = obj.getString("framework", "")
+    if (frameworkId.isEmpty) {
+      Map.empty[String, AnyRef]
+    } else {
+      // Get all metadata keys that could be framework categories
+      val potentialFrameworkKeys = obj.metadata.keys.filter { key =>
+        val isStandard = isStandardField(key)
+        val isInternal = isInternalField(key)
+        val hasValue = hasFrameworkValue(obj.metadata.getOrElse(key, ""))
+        // Include framework category fields but exclude standard fields and internal fields
+        !isStandard && !isInternal && hasValue
+      }
+      
+      val frameworkFields = potentialFrameworkKeys.map { key =>
+        val value = obj.metadata.getOrElse(key, "")
+        key -> value
+      }.toMap
+      
+      frameworkFields
+    }
+  }
+  
+  private def isStandardField(key: String): Boolean = {
+    val standardFieldsList = Set(
+      "name", "description", "keywords", "appIcon", "mimeType", "gradeLevel", 
+      "identifier", "medium", "pkgVersion", "board", "subject", "resourceType", 
+      "primaryCategory", "contentType", "channel", "organisation", "trackable",
+      "artifactUrl", "license", "author", "creator", "audience", "framework", "copyright",
+      "lastStatusChangedOn", "publish_type", "mediaType", "discussionForum",
+      "createdFor", "size", "compatibilityLevel", "os", "lockKey", "code",
+      "showNotification", "version", "language", "dialcodeRequired", "lastSubmittedOn",
+      "interceptionPoints", "idealScreenSize", "contentEncoding", "consumerId",
+      "osId", "contentDisposition", "previewUrl", "credentials", "pkgVersion",
+      "idealScreenDensity", "lastUpdatedOn", "createdOn", "lastPublishedOn",
+      "lastPublishedBy", "createdBy", "lastUpdatedBy", "objectType", "visibility",
+      "ownershipType", "nodeType", "status", "versionKey"
+    )
+    standardFieldsList.contains(key)
+  }
+  
+  private def isInternalField(key: String): Boolean = {
+    key.startsWith("IL_") || key.startsWith("SYS_") || key.startsWith("_") ||
+    Set("versionKey", "status", "createdOn", "lastUpdatedOn", "lastPublishedOn", 
+        "createdBy", "lastUpdatedBy", "lastPublishedBy", "objectType", "visibility", 
+        "ownershipType", "nodeType").contains(key)
+  }
+  
+  private def hasFrameworkValue(value: AnyRef): Boolean = {
+    value match {
+      case s: String => s.nonEmpty && !s.trim.isEmpty
+      case l: List[_] => l.nonEmpty
+      case a: Array[_] => a.nonEmpty
+      case _ => value != null
+    }
   }
 
 }

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/ContentPublishFunction.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/ContentPublishFunction.scala
@@ -90,7 +90,9 @@ class ContentPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil,
           saveOnSuccess(objWithEcar)(neo4JUtil, cassandraUtil, readerConfig, definitionCache, definitionConfig, config)
           pushStreamingUrlEvent(enrichedObj, context)(metrics)
           pushMVCProcessorEvent(enrichedObj, context)(metrics)
-          pushContentMetadataEvent(enrichedObj, context)(metrics)
+          if(config.isAISearchEnabled) {
+            pushContentMetadataEvent(enrichedObj, context)(metrics)
+          }
 
           if(obj.metadata.contains("dialcodes") && config.enableDIALContextUpdate.equalsIgnoreCase("Yes")) {
             //pushDIALcodeContextUpdaterEvent for linked and delinked DIAL codes

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/ContentPublishFunction.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/ContentPublishFunction.scala
@@ -282,7 +282,7 @@ class ContentPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil,
       "createdFor", "size", "compatibilityLevel", "os", "lockKey", "code",
       "showNotification", "version", "language", "dialcodeRequired", "lastSubmittedOn",
       "interceptionPoints", "idealScreenSize", "contentEncoding", "consumerId",
-      "osId", "contentDisposition", "previewUrl", "credentials", "pkgVersion",
+      "osId", "contentDisposition", "previewUrl", "credentials",
       "idealScreenDensity", "lastUpdatedOn", "createdOn", "lastPublishedOn",
       "lastPublishedBy", "createdBy", "lastUpdatedBy", "objectType", "visibility",
       "ownershipType", "nodeType", "status", "versionKey"

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/ContentPublishFunction.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/function/ContentPublishFunction.scala
@@ -16,7 +16,7 @@ import org.sunbird.job.exception.InvalidInputException
 import org.sunbird.job.helper.FailedEventHelper
 import org.sunbird.job.publish.core.{DefinitionConfig, ExtDataConfig, ObjectData}
 import org.sunbird.job.publish.helpers.EcarPackageType
-import org.sunbird.job.util.{CassandraUtil, CloudStorageUtil, HttpUtil, Neo4JUtil}
+import org.sunbird.job.util.{CassandraUtil, CloudStorageUtil, HttpUtil, Neo4JUtil, ScalaJsonUtil}
 import org.sunbird.job.{BaseProcessFunction, Metrics}
 
 import java.lang.reflect.Type
@@ -90,6 +90,7 @@ class ContentPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil,
           saveOnSuccess(objWithEcar)(neo4JUtil, cassandraUtil, readerConfig, definitionCache, definitionConfig, config)
           pushStreamingUrlEvent(enrichedObj, context)(metrics)
           pushMVCProcessorEvent(enrichedObj, context)(metrics)
+          pushContentMetadataEvent(enrichedObj, context)(metrics)
 
           if(obj.metadata.contains("dialcodes") && config.enableDIALContextUpdate.equalsIgnoreCase("Yes")) {
             //pushDIALcodeContextUpdaterEvent for linked and delinked DIAL codes
@@ -196,5 +197,110 @@ class ContentPublishFunction(config: ContentPublishConfig, httpUtil: HttpUtil,
     val event = s"""{"eid":"BE_JOB_REQUEST", "ets": $ets, "mid": "$mid", "actor": {"id": "Post Publish Processor", "type": "System"}, "context":{"pdata":{"ver":"1.0","id":"org.ekstep.platform"}, "channel":"$channelId","env":"${config.jobEnv}"},"object":{"ver":"$ver","id":"${obj.identifier}"},"edata": {"action":"post-publish-process","iteration":1,"identifier":"${obj.identifier}","channel":"$channelId","contentType":"$contentType","status":"$status", "addContextDialCodes": ${addContextDialCodes}, "removeContextDialCodes": ${removeContextDialCodes} }}""".stripMargin
     logger.info(s"Video Streaming Event for identifier ${obj.identifier}  is  : $event")
     event
+  }
+
+  private def pushContentMetadataEvent(obj: ObjectData, context: ProcessFunction[Event, String]#Context)(implicit metrics: Metrics): Unit = {
+    val event = getContentMetadataEvent(obj)
+    context.output(config.contentMetadataEventOutTag, event)
+    try {
+      if (metrics != null) {
+        metrics.incCounter(config.contentPublishSuccessEventCount)
+      }
+    } catch {
+      case e: Exception =>
+        logger.error(s"Error incrementing metrics for ${obj.identifier}: ${e.getMessage}")
+    }
+  }
+
+  def getContentMetadataEvent(obj: ObjectData): String = {
+    // Standard fields
+    val standardFields = Map(
+      "name" -> obj.getString("name", ""),
+      "description" -> obj.getString("description", ""),
+      "keywords" -> obj.metadata.getOrElse("keywords", List.empty),
+      "appIcon" -> obj.getString("appIcon", ""),
+      "mimeType" -> obj.getString("mimeType", ""),
+      "gradeLevel" -> obj.metadata.getOrElse("gradeLevel", List.empty),
+      "identifier" -> obj.getString("identifier", ""),
+      "medium" -> obj.metadata.getOrElse("medium", List.empty),
+      "pkgVersion" -> obj.metadata.getOrElse("pkgVersion", 0),
+      "board" -> obj.getString("board", ""),
+      "subject" -> obj.metadata.getOrElse("subject", List.empty),
+      "resourceType" -> obj.getString("resourceType", ""),
+      "primaryCategory" -> obj.getString("primaryCategory", ""),
+      "contentType" -> obj.getString("contentType", ""),
+      "channel" -> obj.getString("channel", ""),
+      "organisation" -> obj.metadata.getOrElse("organisation", List.empty),
+      "trackable" -> obj.metadata.getOrElse("trackable", Map.empty),
+      "artifactUrl" -> obj.getString("artifactUrl", ""),
+      "license" -> obj.getString("license", ""),
+      "author" -> obj.getString("author", ""),
+      "creator" -> obj.getString("creator", ""),
+      "audience" -> obj.metadata.getOrElse("audience", List.empty)
+    )
+    
+    // Get framework-specific fields
+    val frameworkFields = getFrameworkFields(obj)
+    
+    // Combine standard and framework fields
+    val allFields = standardFields ++ frameworkFields
+    
+    val eventDataJson = ScalaJsonUtil.serialize(allFields)
+    logger.info(s"Content Metadata Event for identifier ${obj.identifier} is: $eventDataJson")
+    eventDataJson
+  }
+  
+  private def getFrameworkFields(obj: ObjectData): Map[String, AnyRef] = {
+    val frameworkId = obj.getString("framework", "")
+    if (frameworkId.isEmpty) {
+      Map.empty[String, AnyRef]
+    } else {
+      // Get all metadata keys that could be framework categories
+      val potentialFrameworkKeys = obj.metadata.keys.filter { key =>
+        // Include framework category fields but exclude standard fields and internal fields
+        !isStandardField(key) && !isInternalField(key) && hasFrameworkValue(obj.metadata.getOrElse(key, ""))
+      }
+      
+      val frameworkFields = potentialFrameworkKeys.map { key =>
+        val value = obj.metadata.getOrElse(key, "")
+        key -> value
+      }.toMap
+      
+      frameworkFields
+    }
+  }
+  
+  private def isStandardField(key: String): Boolean = {
+    val standardFieldsList = Set(
+      "name", "description", "keywords", "appIcon", "mimeType", "gradeLevel", 
+      "identifier", "medium", "pkgVersion", "board", "subject", "resourceType", 
+      "primaryCategory", "contentType", "channel", "organisation", "trackable",
+      "artifactUrl", "license", "author", "creator", "audience", "framework", "copyright",
+      "lastStatusChangedOn", "publish_type", "mediaType", "discussionForum",
+      "createdFor", "size", "compatibilityLevel", "os", "lockKey", "code",
+      "showNotification", "version", "language", "dialcodeRequired", "lastSubmittedOn",
+      "interceptionPoints", "idealScreenSize", "contentEncoding", "consumerId",
+      "osId", "contentDisposition", "previewUrl", "credentials", "pkgVersion",
+      "idealScreenDensity", "lastUpdatedOn", "createdOn", "lastPublishedOn",
+      "lastPublishedBy", "createdBy", "lastUpdatedBy", "objectType", "visibility",
+      "ownershipType", "nodeType", "status", "versionKey"
+    )
+    standardFieldsList.contains(key)
+  }
+  
+  private def isInternalField(key: String): Boolean = {
+    key.startsWith("IL_") || key.startsWith("SYS_") || key.startsWith("_") ||
+    Set("versionKey", "status", "createdOn", "lastUpdatedOn", "lastPublishedOn", 
+        "createdBy", "lastUpdatedBy", "lastPublishedBy", "objectType", "visibility", 
+        "ownershipType", "nodeType").contains(key)
+  }
+  
+  private def hasFrameworkValue(value: AnyRef): Boolean = {
+    value match {
+      case s: String => s.nonEmpty && !s.trim.isEmpty
+      case l: List[_] => l.nonEmpty
+      case a: Array[_] => a.nonEmpty
+      case _ => value != null
+    }
   }
 }

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/task/ContentPublishConfig.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/task/ContentPublishConfig.scala
@@ -102,4 +102,6 @@ class ContentPublishConfig(override val config: Config) extends PublishConfig(co
   val enableDIALContextUpdate: String = if (config.hasPath("enableDIALContextUpdate")) config.getString("enableDIALContextUpdate") else "No"
 
   val isrRelativePathEnabled: Boolean = if (config.hasPath("cloudstorage.metadata.replace_absolute_path")) config.getBoolean("cloudstorage.metadata.replace_absolute_path") else false
+
+  val isAISearchEnabled: Boolean = if (config.hasPath("ai_search_enabled")) config.getBoolean("ai_search_enabled") else false
 }

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/task/ContentPublishConfig.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/task/ContentPublishConfig.scala
@@ -23,6 +23,7 @@ class ContentPublishConfig(override val config: Config) extends PublishConfig(co
   val kafkaInputTopic: String = config.getString("kafka.input.topic")
   val postPublishTopic: String = config.getString("kafka.post_publish.topic")
   val mvcTopic: String = config.getString("kafka.mvc.topic")
+  val contentMetadataTopic: String = config.getString("kafka.content_metadata.topic")
   val kafkaErrorTopic: String = config.getString("kafka.error.topic")
   val inputConsumerName = "content-publish-consumer"
 
@@ -67,6 +68,7 @@ class ContentPublishConfig(override val config: Config) extends PublishConfig(co
   val generatePostPublishProcessTag: OutputTag[String] = OutputTag[String]("post-publish-process-request")
   val mvcProcessorTag: OutputTag[String] = OutputTag[String]("mvc-processor-request")
   val dialcodeContextUpdaterOutTag: OutputTag[String] = OutputTag[String]("dialcode-context-updater-request")
+  val contentMetadataEventOutTag: OutputTag[String] = OutputTag[String]("content-metadata-event-request")
 
   // Service Urls
   val printServiceBaseUrl: String = config.getString("service.print.basePath")

--- a/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/task/ContentPublishStreamTask.scala
+++ b/publish-pipeline/content-publish/src/main/scala/org/sunbird/job/content/task/ContentPublishStreamTask.scala
@@ -34,6 +34,7 @@ class ContentPublishStreamTask(config: ContentPublishConfig, kafkaConnector: Fli
 
     contentPublish.getSideOutput(config.generateVideoStreamingOutTag).addSink(kafkaConnector.kafkaStringSink(config.postPublishTopic))
     contentPublish.getSideOutput(config.mvcProcessorTag).addSink(kafkaConnector.kafkaStringSink(config.mvcTopic))
+    contentPublish.getSideOutput(config.contentMetadataEventOutTag).addSink(kafkaConnector.kafkaStringSink(config.contentMetadataTopic))
     contentPublish.getSideOutput(config.failedEventOutTag).addSink(kafkaConnector.kafkaStringSink(config.kafkaErrorTopic))
 
    val collectionPublish = processStreamTask.getSideOutput(config.collectionPublishOutTag).process(new CollectionPublishFunction(config, httpUtil))


### PR DESCRIPTION
## Summary 

This pull request introduces a new "content metadata" event to the content publish pipeline, enabling the system to emit detailed metadata for published content and collections. The changes involve updating configuration files, adding new event generation logic, and wiring the new event to Kafka for downstream processing.